### PR TITLE
Feature 17 create entry every day

### DIFF
--- a/src/main/kotlin/fi/metatavu/timebank/api/forecast/models/ForecastTimeEntry.kt
+++ b/src/main/kotlin/fi/metatavu/timebank/api/forecast/models/ForecastTimeEntry.kt
@@ -10,7 +10,7 @@ import io.quarkus.runtime.annotations.RegisterForReflection
 @RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
 class ForecastTimeEntry {
-    var id: Int = 0
+    var id: Int? = null
     var person: Int = 0
     @JsonProperty("non_project_time")
     var nonProjectTime: Int? = null

--- a/src/main/kotlin/fi/metatavu/timebank/api/impl/translate/TimeEntryTranslator.kt
+++ b/src/main/kotlin/fi/metatavu/timebank/api/impl/translate/TimeEntryTranslator.kt
@@ -11,14 +11,14 @@ class TimeEntryTranslator: AbstractTranslator<TimeEntry, fi.metatavu.timebank.mo
 
     override fun translate(entity: TimeEntry): fi.metatavu.timebank.model.TimeEntry {
         return fi.metatavu.timebank.model.TimeEntry(
-            forecastId = entity.forecastId!!,
+            entryId = entity.entryId,
+            forecastId = entity.forecastId,
             person = entity.person!!,
             internalTime =  entity.internalTime!!,
             projectTime = entity.projectTime!!,
             date = entity.date!!,
             createdAt = entity.createdAt!!,
             updatedAt = entity.updatedAt!!,
-            id = entity.entryId,
             isVacation = entity.isVacation!!
         )
     }

--- a/src/test/kotlin/fi/metatavu/timebank/api/test/functional/impl/TimeEntriesTestBuilderResource.kt
+++ b/src/test/kotlin/fi/metatavu/timebank/api/test/functional/impl/TimeEntriesTestBuilderResource.kt
@@ -20,7 +20,7 @@ class TimeEntriesTestBuilderResource(
 ): ApiTestBuilderResource<TimeEntry, ApiClient?>(testBuilder, apiClient) {
 
     override fun clean(t: TimeEntry) {
-        api.deleteTimeEntry(t.id!!)
+        api.deleteTimeEntry(t.entryId)
     }
 
     override fun getApi(): TimeEntriesApi {

--- a/src/test/kotlin/fi/metatavu/timebank/api/test/functional/tests/TimeEntriesTest.kt
+++ b/src/test/kotlin/fi/metatavu/timebank/api/test/functional/tests/TimeEntriesTest.kt
@@ -43,7 +43,7 @@ class TimeEntriesTest: AbstractTest() {
 
             assertEquals(17, timeEntries.size)
             assertEquals(1, vacations.size)
-            testBuilder.userA.timeEntries.assertDeleteFail(401, timeEntries[0].id!!)
+            testBuilder.userA.timeEntries.assertDeleteFail(401, timeEntries[0].entryId)
             timeEntries.forEach { timeEntry ->
                 testBuilder.manager.timeEntries.clean(timeEntry)
             }


### PR DESCRIPTION
This feature fixes https://github.com/Metatavu/time-bank-api-v2/issues/15 .

During synchronization the program now checks if there is entry for each day of the week, and if not, creates an empty TimeEntry for given person.

It was feared that handling it this way would cause the synchronization to take too long, but after testing it increased all time synchronization (20 000+ entries) from ~10 minutes to ~20 minutes. In reality synchronization only happens for last two days and therefore there should be no performance issues.