### PR TITLE
Feature 19 restructure worktimecalendars

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,9 @@ repositories {
 val quarkusPlatformGroupId: String by project
 val quarkusPlatformArtifactId: String by project
 val quarkusPlatformVersion: String by project
+val jaxrsFunctionalTestBuilderVersion: String by project
+val wiremockVersion: String by project
+val awaitilityVersion: String by project
 
 dependencies {
     implementation(enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}"))
@@ -44,13 +47,13 @@ dependencies {
     testImplementation("io.quarkus:quarkus-junit5")
     testImplementation("io.quarkus:quarkus-junit5-mockito")
     testImplementation("io.rest-assured:rest-assured")
-    testImplementation("com.github.tomakehurst:wiremock-jre8:2.33.2")
+    testImplementation("com.github.tomakehurst:wiremock-jre8:$wiremockVersion")
     testImplementation("io.quarkus:quarkus-test-keycloak-server")
     testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
-    testImplementation("org.testcontainers:testcontainers:1.17.2")
-    testImplementation("org.testcontainers:mysql:1.17.2")
-    testImplementation("fi.metatavu.jaxrs.testbuilder:jaxrs-functional-test-builder:1.0.6")
-    testImplementation("org.awaitility:awaitility:4.2.0")
+    testImplementation("org.testcontainers:testcontainers")
+    testImplementation("org.testcontainers:mysql")
+    testImplementation("fi.metatavu.jaxrs.testbuilder:jaxrs-functional-test-builder:$jaxrsFunctionalTestBuilderVersion")
+    testImplementation("org.awaitility:awaitility:$awaitilityVersion")
 }
 
 group = "fi.metatavu.timebank"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     testImplementation("org.testcontainers:testcontainers:1.17.2")
     testImplementation("org.testcontainers:mysql:1.17.2")
     testImplementation("fi.metatavu.jaxrs.testbuilder:jaxrs-functional-test-builder:1.0.6")
+    testImplementation("org.awaitility:awaitility:4.2.0")
 }
 
 group = "fi.metatavu.timebank"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,6 @@ val quarkusPlatformArtifactId: String by project
 val quarkusPlatformVersion: String by project
 val jaxrsFunctionalTestBuilderVersion: String by project
 val wiremockVersion: String by project
-val awaitilityVersion: String by project
 
 dependencies {
     implementation(enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}"))
@@ -53,7 +52,6 @@ dependencies {
     testImplementation("org.testcontainers:testcontainers")
     testImplementation("org.testcontainers:mysql")
     testImplementation("fi.metatavu.jaxrs.testbuilder:jaxrs-functional-test-builder:$jaxrsFunctionalTestBuilderVersion")
-    testImplementation("org.awaitility:awaitility:$awaitilityVersion")
 }
 
 group = "fi.metatavu.timebank"

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,6 @@ quarkusPluginId=io.quarkus
 quarkusPlatformGroupId=io.quarkus
 quarkusPlatformVersion=2.9.0.Final
 org.gradle.jvmargs=-Xmx2024m -XX:MaxPermSize=512m
+jaxrsFunctionalTestBuilderVersion=1.0.6
+wiremockVersion=2.33.2
+awaitilityVersion=4.2.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,3 @@ quarkusPlatformVersion=2.9.0.Final
 org.gradle.jvmargs=-Xmx2024m -XX:MaxPermSize=512m
 jaxrsFunctionalTestBuilderVersion=1.0.6
 wiremockVersion=2.33.2
-awaitilityVersion=4.2.0

--- a/src/main/kotlin/fi/metatavu/timebank/api/controllers/DailyEntryController.kt
+++ b/src/main/kotlin/fi/metatavu/timebank/api/controllers/DailyEntryController.kt
@@ -112,7 +112,7 @@ class DailyEntryController {
         val worktimeCalendar = personsWorktimeCalendars.find {
             it.calendarStart!! <= date && it.calendarEnd == null ||
             it.calendarStart!! <= date && it.calendarEnd!! >= date
-        }
+        } ?: throw Error("Couldn't find WorktimeCalendar for person $personId at $date!")
 
         entriesOfDay.forEach{ entry ->
             internalTime += entry.internalTime ?: 0
@@ -121,7 +121,7 @@ class DailyEntryController {
         }
 
         val expected = getDailyExpected(
-            worktimeCalendar = worktimeCalendar!!,
+            worktimeCalendar = worktimeCalendar,
             holidays = holidays,
             day = date
         )

--- a/src/main/kotlin/fi/metatavu/timebank/api/controllers/PersonsController.kt
+++ b/src/main/kotlin/fi/metatavu/timebank/api/controllers/PersonsController.kt
@@ -75,12 +75,13 @@ class PersonsController {
 
     /**
      * List persons data from Forecast API
+     * Filters out system users since they should not be needed in this application
      *
      * @return List of ForecastPersons
      */
     suspend fun getPersonsFromForecast(): List<ForecastPerson> {
         return try {
-            forecastService.getPersons()
+            forecastService.getPersons().filter { !it.isSystemUser }
         } catch (e: Error) {
             logger.error("Error when requesting persons from Forecast API: ${e.localizedMessage}")
             throw Error(e.localizedMessage)
@@ -105,13 +106,13 @@ class PersonsController {
     }
 
     /**
-     * Filters inactive Forecast persons, system users and clients
+     * Filters inactive Forecast persons and clients
      *
      * @param persons List of ForecastPersons
      * @return List of Forecast persons
      */
     fun filterPersons(persons: List<ForecastPerson>): List<ForecastPerson> {
-        return persons.filter{ person -> person.active && !person.isSystemUser && person.clientId == null }
+        return persons.filter{ person -> person.active &&  person.clientId == null }
     }
 
     /**

--- a/src/main/kotlin/fi/metatavu/timebank/api/controllers/SynchronizeController.kt
+++ b/src/main/kotlin/fi/metatavu/timebank/api/controllers/SynchronizeController.kt
@@ -43,9 +43,7 @@ class SynchronizeController {
         try {
             var forecastPersons = personsController.getPersonsFromForecast()
 
-            val worktimeCalendars = forecastPersons.map { person ->
-                worktimeCalendarController.checkWorktimeCalendar(person)
-            }
+            forecastPersons.forEach { worktimeCalendarController.checkWorktimeCalendar(it) }
 
             forecastPersons = personsController.filterPersons(forecastPersons)
 
@@ -60,7 +58,7 @@ class SynchronizeController {
                 val personName = "${person?.lastName}, ${person?.firstName}"
                 logger.info("Synchronizing TimeEntry ${idx + 1}/${entries.size} of $personName...")
 
-                if (timeEntryController.createEntry(timeEntry, worktimeCalendars, tasks)) {
+                if (timeEntryController.createEntry(timeEntry, tasks)) {
                     synchronized++
                     logger.info("Synchronized TimeEntry #${idx + 1}!")
                 } else {

--- a/src/main/kotlin/fi/metatavu/timebank/api/controllers/TimeEntryController.kt
+++ b/src/main/kotlin/fi/metatavu/timebank/api/controllers/TimeEntryController.kt
@@ -3,7 +3,6 @@ package fi.metatavu.timebank.api.controllers
 import fi.metatavu.timebank.api.forecast.models.ForecastTask
 import fi.metatavu.timebank.api.forecast.models.ForecastTimeEntry
 import fi.metatavu.timebank.api.persistence.model.TimeEntry
-import fi.metatavu.timebank.api.persistence.model.WorktimeCalendar
 import fi.metatavu.timebank.api.persistence.repositories.TimeEntryRepository
 import fi.metatavu.timebank.api.utils.VacationUtils
 import java.time.LocalDate
@@ -43,15 +42,11 @@ class TimeEntryController {
      * Creates and persists new TimeEntry
      *
      * @param forecastTimeEntry ForecastTimeEntry
-     * @param worktimeCalendars List of WorktimeCalendars
      * @param forecastTasks List of ForecastTasks
      * @return boolean whether operation was successful
      */
     suspend fun createEntry(
-        forecastTimeEntry: ForecastTimeEntry,
-        worktimeCalendars: List<WorktimeCalendar>,
-        forecastTasks: List<ForecastTask>
-    ): Boolean {
+        forecastTimeEntry: ForecastTimeEntry, forecastTasks: List<ForecastTask>): Boolean {
         val nonBillableTask = forecastTasks.find { it.id == forecastTimeEntry.task }?.unBillable ?: true
         val internalTime = forecastTimeEntry.nonProjectTime != null
         val newTimeEntry = TimeEntry()
@@ -71,7 +66,6 @@ class TimeEntryController {
         newTimeEntry.date = LocalDate.parse(forecastTimeEntry.date)
         newTimeEntry.createdAt = OffsetDateTime.parse(forecastTimeEntry.createdAt)
         newTimeEntry.updatedAt = OffsetDateTime.parse(forecastTimeEntry.updatedAt)
-        newTimeEntry.worktimeCalendar = worktimeCalendars.find { it.personId == forecastTimeEntry.person }
         newTimeEntry.isVacation = forecastTimeEntry.nonProjectTime == VacationUtils.VACATION_ID
 
         return timeEntryRepository.persistEntry(newTimeEntry)

--- a/src/main/kotlin/fi/metatavu/timebank/api/persistence/model/TimeEntry.kt
+++ b/src/main/kotlin/fi/metatavu/timebank/api/persistence/model/TimeEntry.kt
@@ -6,7 +6,6 @@ import java.util.*
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Id
-import javax.persistence.ManyToOne
 
 /**
  * TimeEntry JPA entity
@@ -42,9 +41,6 @@ class TimeEntry {
     @Column
     var updatedAt: OffsetDateTime? = null
 
-    @ManyToOne
-    var worktimeCalendar: WorktimeCalendar? = null
-
     @Column
     var isVacation: Boolean? = false
 
@@ -61,7 +57,6 @@ class TimeEntry {
             nonBillableProjectTime == other.nonBillableProjectTime &&
             date == other.date &&
             createdAt == other.createdAt &&
-            updatedAt == other.updatedAt  &&
-            worktimeCalendar == other.worktimeCalendar
+            updatedAt == other.updatedAt
     }
 }

--- a/src/main/kotlin/fi/metatavu/timebank/api/persistence/repositories/WorktimeCalendarRepository.kt
+++ b/src/main/kotlin/fi/metatavu/timebank/api/persistence/repositories/WorktimeCalendarRepository.kt
@@ -15,40 +15,24 @@ import javax.enterprise.context.ApplicationScoped
 class WorktimeCalendarRepository: PanacheRepositoryBase<WorktimeCalendar, UUID> {
 
     /**
-     * Gets most up-to-date WorktimeCalendars for given person
+     * Gets all WorktimeCalendars for given Person
      *
-     * @param personId person id
-     * @return WorktimeCalendars
+     * @param personId
+     * @return List of WorktimeCalendars
      */
-    suspend fun getUpToDateWorktimeCalendar(personId: Int): WorktimeCalendar? {
-        return try {
-            find("personId = ?1 AND calendarEnd = NULL", personId).singleResult<WorktimeCalendar?>().awaitSuspending()
-        } catch (ex: Exception) {
-            null
-        }
-    }
-
-    /**
-     * Gets WorktimeCalendar based on id
-     *
-     * @param id id
-     * @return WorktimeCalendar
-     */
-    suspend fun getWorktimeCalendar(id: UUID): WorktimeCalendar {
-        return findById(id).awaitSuspending()
+    suspend fun getAllWorkTimeCalendarsByPerson(personId: Int): List<WorktimeCalendar>? {
+        return find("personId = ?1", personId).list<WorktimeCalendar?>().awaitSuspending()
     }
 
     /**
      * Updates persisted WorktimeCalendar
      *
      * @param id id
+     * @param calendarEnd calendarEnd
      */
-    suspend fun updateWorktimeCalendar(id: UUID) {
+    suspend fun updateWorktimeCalendar(id: UUID, calendarEnd: LocalDate) {
         Panache.withTransaction {
-            update(
-                "calendarEnd = ?1 WHERE id = ?2",
-                LocalDate.now().minusDays(1), id
-            )
+            update("calendarEnd = ?1 WHERE id = ?2", calendarEnd, id)
         }.awaitSuspending()
     }
 
@@ -56,7 +40,6 @@ class WorktimeCalendarRepository: PanacheRepositoryBase<WorktimeCalendar, UUID> 
      * Persists new WorktimeCalendar
      *
      * @param worktimeCalendar WorktimeCalendar
-     * @return worktimeCalendar WorktimeCalendar
      */
     suspend fun persistWorktimeCalendar(worktimeCalendar: WorktimeCalendar){
         Panache.withTransaction {

--- a/src/main/resources/db/changeLog.xml
+++ b/src/main/resources/db/changeLog.xml
@@ -57,4 +57,8 @@
     <changeSet id="timeEntry_entryId_to_id" author="Ville Juutila">
         <renameColumn tableName="TimeEntry" oldColumnName="entryId" newColumnName="id" columnDataType="binary(16)" />
     </changeSet>
+    <changeSet id="remove_worktimeCalendar_constraint" author="Ville Juutila">
+        <dropForeignKeyConstraint baseTableName="TimeEntry" constraintName="FK_TIME_ENTRY_WORKTIME_CALENDAR" />
+        <dropColumn tableName="TimeEntry" columnName="worktimeCalendar_id" />
+    </changeSet>
 </databaseChangeLog>

--- a/src/test/kotlin/fi/metatavu/timebank/api/test/functional/data/TestTimeEntriesData.kt
+++ b/src/test/kotlin/fi/metatavu/timebank/api/test/functional/data/TestTimeEntriesData.kt
@@ -227,7 +227,7 @@ class TestTimeEntriesData {
         fun getForecastTimeEntryForUpdatedPerson(): List<ForecastTimeEntry> {
             return listOf(
                 createTestTimeEntry(
-                    id = 15,
+                    id = 17,
                     person = 5,
                     task = 123,
                     nonProjectTime = 789,

--- a/src/test/kotlin/fi/metatavu/timebank/api/test/functional/impl/DailyEntriesTestBuilderResource.kt
+++ b/src/test/kotlin/fi/metatavu/timebank/api/test/functional/impl/DailyEntriesTestBuilderResource.kt
@@ -8,6 +8,7 @@ import fi.metatavu.timebank.test.client.infrastructure.ApiClient
 import fi.metatavu.timebank.test.client.infrastructure.ClientException
 import fi.metatavu.timebank.test.client.infrastructure.ServerException
 import fi.metatavu.timebank.test.client.models.DailyEntry
+import java.util.concurrent.Callable
 import org.junit.Assert
 
 /**
@@ -66,6 +67,27 @@ class DailyEntriesTestBuilderResource(
                 is ClientException -> assertClientExceptionStatus(expectedStatus, ex)
                 is ServerException -> assertServerExceptionStatus(expectedStatus, ex)
             }
+        }
+    }
+
+    /**
+     * Checks if DailyEntries contains entry matching given details
+     *
+     * @param personId personId
+     * @param before before
+     * @param after after
+     * @param vacation vacation
+     * @param expected expected worktime
+     * @return Boolean whether criteria matched
+     */
+    fun checkDailyEntries(personId: Int?, before: String?, after: String?, vacation: Boolean?, expected: Int): Callable<Boolean> {
+        return Callable {
+            getDailyEntries(
+                personId = personId,
+                before = before,
+                after = after,
+                vacation = vacation
+            )[0].expected == expected
         }
     }
 }

--- a/src/test/kotlin/fi/metatavu/timebank/api/test/functional/impl/DailyEntriesTestBuilderResource.kt
+++ b/src/test/kotlin/fi/metatavu/timebank/api/test/functional/impl/DailyEntriesTestBuilderResource.kt
@@ -8,7 +8,6 @@ import fi.metatavu.timebank.test.client.infrastructure.ApiClient
 import fi.metatavu.timebank.test.client.infrastructure.ClientException
 import fi.metatavu.timebank.test.client.infrastructure.ServerException
 import fi.metatavu.timebank.test.client.models.DailyEntry
-import java.util.concurrent.Callable
 import org.junit.Assert
 
 /**
@@ -67,28 +66,6 @@ class DailyEntriesTestBuilderResource(
                 is ClientException -> assertClientExceptionStatus(expectedStatus, ex)
                 is ServerException -> assertServerExceptionStatus(expectedStatus, ex)
             }
-        }
-    }
-
-    /**
-     * Checks if DailyEntries contains entry matching given details
-     *
-     * @param personId personId
-     * @param before before
-     * @param after after
-     * @param vacation vacation
-     * @param expected expected worktime
-     * @return Boolean whether criteria matched
-     */
-    fun checkDailyEntries(personId: Int?, before: String?, after: String?, vacation: Boolean?, expected: Int): Callable<Boolean> {
-        return Callable {
-            val entries = getDailyEntries(
-                personId = personId,
-                before = before,
-                after = after,
-                vacation = vacation
-            )
-            entries[0].expected == expected && entries.size == 1
         }
     }
 }

--- a/src/test/kotlin/fi/metatavu/timebank/api/test/functional/impl/DailyEntriesTestBuilderResource.kt
+++ b/src/test/kotlin/fi/metatavu/timebank/api/test/functional/impl/DailyEntriesTestBuilderResource.kt
@@ -82,12 +82,13 @@ class DailyEntriesTestBuilderResource(
      */
     fun checkDailyEntries(personId: Int?, before: String?, after: String?, vacation: Boolean?, expected: Int): Callable<Boolean> {
         return Callable {
-            getDailyEntries(
+            val entries = getDailyEntries(
                 personId = personId,
                 before = before,
                 after = after,
                 vacation = vacation
-            )[0].expected == expected
+            )
+            entries[0].expected == expected && entries.size == 1
         }
     }
 }

--- a/src/test/kotlin/fi/metatavu/timebank/api/test/functional/resources/TestWiremockResource.kt
+++ b/src/test/kotlin/fi/metatavu/timebank/api/test/functional/resources/TestWiremockResource.kt
@@ -141,7 +141,7 @@ class TestWiremockResource: QuarkusTestResourceLifecycleManager {
                 .willReturn(jsonResponse(objectMapper.writeValueAsString(TestData.getUpdatedForecastTimeEntryResponse()), 200))
         )
         wireMockServer.stubFor(
-            get(urlPathEqualTo("/v4/time_registrations/updated_after/${getPathParamDate(LocalDate.now().minusDays(1))}"))
+            get(urlPathEqualTo("/v4/time_registrations/updated_after/${getPathParamDate(LocalDate.now())}"))
                 .inScenario(TIMES_SCENARIO)
                 .whenScenarioStateIs(UPDATE_STATE_ONE)
                 .willSetStateTo(STARTED)

--- a/src/test/kotlin/fi/metatavu/timebank/api/test/functional/tests/DailyEntriesTest.kt
+++ b/src/test/kotlin/fi/metatavu/timebank/api/test/functional/tests/DailyEntriesTest.kt
@@ -14,9 +14,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import fi.metatavu.timebank.api.test.functional.data.TestDateUtils.Companion.getThirtyDaysAgo
 import java.time.LocalDate
-import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.awaitility.Awaitility.*
 
 /**
  * Tests for DailyEntries API
@@ -153,16 +151,6 @@ class DailyEntriesTest: AbstractTest() {
             testBuilder.manager.synchronization.synchronizeEntries(
                 before = null,
                 after = LocalDate.now().toString()
-            )
-
-            await().atMost(1, TimeUnit.MINUTES).until(
-                testBuilder.manager.dailyEntries.checkDailyEntries(
-                    personId = 5,
-                    before = null,
-                    after = LocalDate.now().toString(),
-                    vacation = null,
-                    expected = 217
-                )
             )
 
             val secondEntries = testBuilder.manager.dailyEntries.getDailyEntries(

--- a/src/test/kotlin/fi/metatavu/timebank/api/test/functional/tests/PersonsTest.kt
+++ b/src/test/kotlin/fi/metatavu/timebank/api/test/functional/tests/PersonsTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Assertions.*
 import fi.metatavu.timebank.api.test.functional.data.TestDateUtils.Companion.getThirtyDaysAgo
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
+import kotlin.math.ceil
 
 /**
  * Tests for Person API
@@ -68,7 +69,7 @@ class PersonsTest: AbstractTest() {
         createTestBuilder().use { testBuilder ->
             val persons = testBuilder.manager.persons.getPersons(active = false)
 
-            assertEquals(5, persons.size)
+            assertEquals(4, persons.size)
             testBuilder.notValid.persons.assertListFail(401)
         }
     }
@@ -196,13 +197,15 @@ class PersonsTest: AbstractTest() {
                 timespan = Timespan.WEEK
             )
 
-            assertEquals(5, personTotalTimes.size)
-            assertEquals(372, personTotalTimes[4].internalTime)
-            assertEquals(122, personTotalTimes[4].billableProjectTime)
-            assertEquals(494, personTotalTimes[4].logged)
-            assertEquals(122, personTotalTimes[3].nonBillableProjectTime)
-            assertEquals(52, personTotalTimes[3].billableProjectTime)
-            assertEquals(378, personTotalTimes[3].internalTime)
+            val expectedWeeks = ceil(daysBetweenMonth / 7.toDouble()).toInt()
+
+            assertEquals(expectedWeeks, personTotalTimes.size)
+            assertTrue(personTotalTimes.find { it.internalTime == 372 } != null)
+            assertTrue(personTotalTimes.find { it.billableProjectTime == 122 } != null)
+            assertTrue(personTotalTimes.find { it.logged == 494 } != null)
+            assertTrue(personTotalTimes.find { it.nonBillableProjectTime == 122 } != null)
+            assertTrue(personTotalTimes.find { it.billableProjectTime == 52 } != null)
+            assertTrue(personTotalTimes.find { it.internalTime == 378 } != null)
             personTotalTimes.forEach {
                 assertTrue(it.balance < 0)
             }


### PR DESCRIPTION
Fixes #19 and continues where #20 left.

- TimeEntry_WorktimeCalendar foreign key constraint removed
- WorktimeCalendars for x-date are retrieved by date now, instead of id of WorktimeCalendar
 - Fixes issues for days when Persons worktimes has changed middle of the day and entries for same day would refer to different WorktimeCalendars.
 - Tests should now properly have dynamic dates