### PR TITLE
Prevents entries with date prior to 31.7.2021 of ending up into the software.

### DIFF
--- a/src/main/kotlin/fi/metatavu/timebank/api/controllers/SynchronizeController.kt
+++ b/src/main/kotlin/fi/metatavu/timebank/api/controllers/SynchronizeController.kt
@@ -148,7 +148,7 @@ class SynchronizeController {
      * @return List of ForecastTimeEntries
      */
     private suspend fun synchronizationDayValidator(timeEntries: List<ForecastTimeEntry>, persons: List<ForecastPerson>): List<ForecastTimeEntry> {
-        val sortedEntries = timeEntries.sortedBy { it.date }.toMutableList()
+        val sortedEntries = timeEntries.sortedBy { it.date }.filter { LocalDate.parse(it.date) > oldestSyncDate }.toMutableList()
         var firstEntryDate = LocalDate.parse(sortedEntries.first().date)
         if (firstEntryDate < oldestSyncDate) firstEntryDate = oldestSyncDate
 

--- a/src/test/kotlin/fi/metatavu/timebank/api/test/functional/tests/PersonsTest.kt
+++ b/src/test/kotlin/fi/metatavu/timebank/api/test/functional/tests/PersonsTest.kt
@@ -177,12 +177,23 @@ class PersonsTest: AbstractTest() {
                 personId = 3,
                 timespan = Timespan.MONTH
             )
-
+            personTotalTimes.forEach {
+                println("PersonTotalTime(" +
+                        "\n\tinternalTime: ${it.internalTime}" +
+                        "\n\tbillableProjectTime: ${it.billableProjectTime}" +
+                        "\n\tnonBillableProjectTime: ${it.nonBillableProjectTime}" +
+                        "\n\tloggedProjectTime: ${it.loggedProjectTime}" +
+                        "\n\tlogged: ${it.logged}" +
+                        "\n\texpected: ${it.expected}" +
+                        "\n\tbalance: ${it.balance}" +
+                        "\n\ttimePeriod: ${it.timePeriod})")
+            }
             assertEquals(amountOfMonths.toInt(), personTotalTimes.size)
-            assertEquals(122, personTotalTimes[1].nonBillableProjectTime)
-            assertEquals(174, personTotalTimes[1].billableProjectTime)
-            assertEquals(296, personTotalTimes[1].loggedProjectTime)
-            assertTrue(personTotalTimes[0].balance < 0)
+            assertTrue(personTotalTimes.find { it.nonBillableProjectTime == 122 } != null)
+            assertTrue(personTotalTimes.find { it.internalTime == 372 } != null)
+            assertTrue(personTotalTimes.find { it.billableProjectTime == 52 } != null)
+            assertTrue(personTotalTimes.find { it.loggedProjectTime == 174 } != null)
+            assertTrue(personTotalTimes.all { it.balance < 0 } )
         }
     }
 

--- a/src/test/kotlin/fi/metatavu/timebank/api/test/functional/tests/PersonsTest.kt
+++ b/src/test/kotlin/fi/metatavu/timebank/api/test/functional/tests/PersonsTest.kt
@@ -177,17 +177,7 @@ class PersonsTest: AbstractTest() {
                 personId = 3,
                 timespan = Timespan.MONTH
             )
-            personTotalTimes.forEach {
-                println("PersonTotalTime(" +
-                        "\n\tinternalTime: ${it.internalTime}" +
-                        "\n\tbillableProjectTime: ${it.billableProjectTime}" +
-                        "\n\tnonBillableProjectTime: ${it.nonBillableProjectTime}" +
-                        "\n\tloggedProjectTime: ${it.loggedProjectTime}" +
-                        "\n\tlogged: ${it.logged}" +
-                        "\n\texpected: ${it.expected}" +
-                        "\n\tbalance: ${it.balance}" +
-                        "\n\ttimePeriod: ${it.timePeriod})")
-            }
+
             assertEquals(amountOfMonths.toInt(), personTotalTimes.size)
             assertTrue(personTotalTimes.find { it.nonBillableProjectTime == 122 } != null)
             assertTrue(personTotalTimes.find { it.internalTime == 372 } != null)


### PR DESCRIPTION
Resolves #24 